### PR TITLE
fix: typo in License section (Liscense -> License)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ This repository contains intentionally seeded bugs for educational purposes. See
 
 ## License
 
-MIT Liscense
+MIT License


### PR DESCRIPTION
Fixed typo in README.md: Liscense -> License

Closes #6