### PR TITLE
fix: correct typo Liscense→License in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ This repository contains intentionally seeded bugs for educational purposes. See
 
 ## License
 
-MIT Liscense
+MIT License


### PR DESCRIPTION
Fixes #6. Simple typo fix in README.md License section.