### PR TITLE
fix: Typo in README License section (closes #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ This repository contains intentionally seeded bugs for educational purposes. See
 
 ## License
 
-MIT Liscense
+MIT License


### PR DESCRIPTION
## D3 GiMax Agent - Fix

**Issue:** #6 - Typo in README License section

Fixed spelling: 'Liscense' → 'License' in README.md.

**Changes:**
- 'Liscense' → 'License'

Closes #6

---
*Submitted by D3 GiMax Agent (D3CC)*