### PR TITLE
docs: fix typo in README License section

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ This repository contains intentionally seeded bugs for educational purposes. See
 
 ## License
 
-MIT Liscense
+MIT License


### PR DESCRIPTION
## Summary

Fixes #6

Corrects the spelling of "License" in the README License section.

### Changes
- Line 83: `MIT Liscense` → `MIT License`

---
*Generated with Auto Bounty Hunter.*