### PR TITLE
docs: fix 'Liscense' typo to 'License' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ This repository contains intentionally seeded bugs for educational purposes. See
 
 ## License
 
-MIT Liscense
+MIT License


### PR DESCRIPTION
## Summary

Fixed a minor typo in the README.md file where "MIT Liscense" was misspelled as "MIT License".

## Changes

- Corrected the spelling of "License" in the License section of README.md

## Checklist

- [x] I have verified the fix is correct
- [x] This is a documentation-only change with no functional impact