### PR TITLE
Fix #6: correct typo 'Liscense' to 'License' in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ This repository contains intentionally seeded bugs for educational purposes. See
 
 ## License
 
-MIT Liscense
+MIT License


### PR DESCRIPTION
## Summary
Fixes typo in README.md License section.

## Changes
- Corrected spelling from `Liscense` to `License` (line 83)

## Related
Closes #6